### PR TITLE
Add Azure AD publisher domain verification file

### DIFF
--- a/.well-known/microsoft-identity-association.json
+++ b/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "0a7d2466-0368-459d-9d19-db4664742288"
+    }
+  ]
+}


### PR DESCRIPTION
## Publisher Domain Verification

This PR adds the Microsoft identity association file required for Azure AD publisher domain verification.

### 📋 Details
- **Application ID**: `0a7d2466-0368-459d-9d19-db4664742288`
- **Verification File**: `.well-known/microsoft-identity-association.json`
- **Purpose**: Removes 'unverified' warnings from Azure AD consent screens

### 🔗 Verification URL
After merging, the verification file will be accessible at:
https://petems.github.io/.well-known/microsoft-identity-association.json

### 📚 Documentation
- [Publisher verification overview](https://docs.microsoft.com/en-us/azure/active-directory/develop/publisher-verification-overview)
- [Configure publisher domain](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-configure-publisher-domain)

### ✅ Next Steps
1. Merge this PR
2. In Azure Portal → App registrations → Branding:
   - Set publisher domain to: `petems.github.io`
   - Azure will automatically verify using this file